### PR TITLE
Update ros2 to humble in build test workflow

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -7,17 +7,17 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     strategy:
       fail-fast: false
     env:
-      ROS_DISTRO: foxy
+      ROS_DISTRO: humble
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -30,7 +30,6 @@ jobs:
           libboost-system-dev \
           libboost-program-options-dev \
           libboost-iostreams-dev \
-          libboost-filesystem-dev \
           libeigen3-dev \
           uuid-dev \
           libxfixes-dev \
@@ -40,7 +39,8 @@ jobs:
           zlib1g-dev \
           libjpeg-dev \
           libpng-dev \
-          qt5-default \
+          libfreetype-dev \
+          qtbase5-dev \
           libqt5x11extras5-dev \
           libqt5svg5-dev \
           qttranslations5-l10n \

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install dependencies of choreonoid
         run: |
+          apt-get update && \
+          apt-get -y upgrade && \
           apt-get -y install \
           build-essential \
           cmake-curses-gui \


### PR DESCRIPTION
Use latest ROS 2 LTS distribution, "Humble" in build testing workflow. 